### PR TITLE
Add image slider before weekly offers section

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,22 +28,6 @@
         </nav>
         <div class="hamburger-menu" onclick="openNav()">☰</div>
     </header>
-
-    <!-- ======================= SLIDER DE IMÁGENES ======================= -->
- <div class="slider-container">
-    <div class="slider-track">
-        <!-- Coloca tus 4 imágenes de slider aquí -->
- <!--       <div class="slide"><img src="slider/slide1.jpg" alt="Banner promocional 1"></div>
-        <div class="slide"><img src="slider/slide2.jpg" alt="Banner promocional 2"></div>
-        <div class="slide"><img src="slider/slide3.jpg" alt="Banner promocional 3"></div>
-        <div class="slide"><img src="slider/slide4.jpg" alt="Banner promocional 4"></div>
-    </div>-->
-    <div class="slider-dots">
-        <!-- Los puntos de navegación se generarán aquí con JavaScript -->
-    </div>
-</div>
-<!-- =================== FIN DEL SLIDER DE IMÁGENES =================== -->
-
     <div id="mySidebar" class="sidebar">
         <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">×</a>
         <a href="#">Ofertas</a>
@@ -57,6 +41,16 @@
     </div>
 
     <main class="offers-section">
+        <!-- Slider de imágenes -->
+        <div class="slider-container">
+            <div class="slider-track">
+                <div class="slide"><img src="https://picsum.photos/id/1015/1200/450" alt="Banner promocional 1"></div>
+                <div class="slide"><img src="https://picsum.photos/id/1016/1200/450" alt="Banner promocional 2"></div>
+                <div class="slide"><img src="https://picsum.photos/id/1018/1200/450" alt="Banner promocional 3"></div>
+            </div>
+            <div class="slider-dots"></div>
+        </div>
+
         <h2>🔥 ¡Ofertas de la Semana!</h2>
 
         <div id="daily-deals-container" class="daily-deals">


### PR DESCRIPTION
## Summary
- Display a three-image slider before the weekly offers title to showcase promotional banners.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4baa32d0832da574d6b41fe995f8